### PR TITLE
feat : axios 인스턴스 설정 및 요청/응답 인터셉터 구현

### DIFF
--- a/src/apis/authService.ts
+++ b/src/apis/authService.ts
@@ -1,0 +1,11 @@
+export const getAccessToken = () => {
+  return localStorage.getItem('accessToken');
+};
+
+export const setAccessToken = (token: string) => {
+  localStorage.setItem('accessToken', token);
+};
+
+export const removeAccessToken = () => {
+  localStorage.removeItem('accessToken');
+};

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,0 +1,101 @@
+import axios, {
+  AxiosError,
+  AxiosInstance,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';
+import {
+  getAccessToken,
+  removeAccessToken,
+  setAccessToken,
+} from './authService';
+
+// Axios 인스턴스 생성
+const axiosInstance: AxiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  timeout: 10000, // 요청 타임아웃 (10초)
+  headers: {
+    'Content-Type': 'application/json',
+    // 필요 시 헤더 추가
+  },
+});
+
+// 요청 인터셉터 - Access Token 자동 추가
+axiosInstance.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    // JWT 토큰을 localStorage에서 가져옴
+    const token = getAccessToken(); // 쿠키로 변경 가능
+
+    // 토큰이 필요하지 않은 엔드포인트
+    // 로그인, 회원가입과 같은 비회원용 엔드포인트 목록입니다.
+    const pubicEndpoints = [
+      '/login',
+      '/user/signup',
+      '/user/signup/email-send',
+      '/user/signup/email-verify',
+      '/user/signup/nickname-verify',
+      '/oauth2/authorization/google',
+      '/crew',
+      '/region',
+      '/crew/regular',
+      'crew/{crew_id}/regular',
+      '/crew/{crew_id}/regular/{regular_id}',
+      // '/crew/{crew_id}',
+    ];
+
+    // 토큰이 필요한 엔드포인트에만 토큰을 헤더에 추가
+    if (
+      token &&
+      !pubicEndpoints.some((endpoint) => config.url?.startsWith(endpoint))
+    ) {
+      if (config.headers) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+    }
+    return config;
+  },
+  (error: AxiosError) => {
+    return Promise.reject(error); // 요청 에러 시 에러 처리
+  },
+);
+
+// 응답 인터셉터 - 401 에러 처리, 토큰 갱신
+// 401 에러(Unauthorized)가 발생할 경우, 토큰을 갱신하고 원래 요청을 다시 시도합니다.
+axiosInstance.interceptors.response.use(
+  (response: AxiosResponse) => response, // 응답이 정상일 경우 그대로 반환
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & {
+      _retry?: boolean;
+    };
+
+    // 401 에러가 발생하고, 이 요청이 처음 시도된 경우
+    if (
+      error.response &&
+      error.response.status === 401 &&
+      !originalRequest._retry
+    ) {
+      originalRequest._retry = true; // 이 요청이 재시도 중임을 표시
+
+      try {
+        // 토큰 갱신 요청
+        const { data } = await axiosInstance.post('/token/refresh');
+        const newAccessToken = data.accessToken;
+
+        // 새로 발급된 토큰은 localStorage에 저장하고, 헤더 업데이트
+        setAccessToken(newAccessToken);
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
+        // 원래 요청을 다시 시도
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        // 토큰 갱신실패 시, 토큰을 삭제하고 로그인 페이지로 리다이렉트
+        removeAccessToken();
+        alert('세션이 만료되었습니다. 다시 로그인해 주세요.');
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 프로젝트 내에서 API 요청을 일관되게 처리하고, 반복되는 코드 작성을 줄이기 위함
- 인증이 필요한 요청에 대해 JWT 토큰을 자동으로 처리하고, 토큰 만료 시 자동으로 갱신하는 기능을 추가하여 보안을 강화
- 향후 API 연결 작업을 더 쉽게 하고, 유지 보수성을 높이는 것을 목표로 함

### 이 PR에서 변경된 사항
**1. axios 인스턴스 생성** 
- 모든 API 요청에 사용할 axiosInstance를 생성.

**2. 요청 인터셉터 추가**
- 사용자가 로그인된 상태에서 JWT 토큰을 Authorization 헤더에 자동으로 추가하도록 설정
- 로그인, 회원가입 등 비회원용 API 요청에는 토큰이 추가되지 않도록 예외 처리를 추가

**3. 응답 인터셉터 추가**
- 서버로부터 401 응답을 받을 경우, 자동으로 토큰을 갱신하고 원래 요청을 다시 시도하는 기능 구현
- 토큰 갱신에 실패할 경우, 세션 만료 메시지를 표시하고, 사용자를 로그인 페이지로 리다이랙트 하도록 함

**4. authService 파일에서의 토큰 관리**
- getAccessToken : 로컬 스토리지에서 accessToken을 가져오는 함수
- setAccessToken : 토큰이 갱신되거나, 사용자가 처음 로그인 할 때 로컬 스토리지에 acessToken을 저장하는 함수.
- removeAccessToken : 사용자가 로그아웃 하거나, 토큰이 만료되었을 때 로컬 스토리지에서 accessToken을 삭제하는 함수

### 참고 스크린샷
<img width="243" alt="image" src="https://github.com/user-attachments/assets/9a35ce1c-d097-4669-8404-55cac7482132">

### 기타
**-  .env.local 파일을 프로젝트 루트에 생성하여 다음과 같이 API BASE URL 설정해야 함**
```
NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
```
- axiosInstance 사용 예시
```
import axiosInstance from './axiosInstance';

const loginUser = async (email: string, password: string) => {
  try {
    const response = await axiosInstance.post('/login', { email, password });
    const { accessToken } = response.data;
    setAccessToken(accessToken);
    // 로그인 성공 처리
  } catch (error) {
    console.error('로그인 실패:', error);
    // 로그인 실패 처리
  }
};
```
- 다른 Content-type을 사용해야 하는 경우 예시
```
axiosInstance.post('/your-endpoint', formData, {
  headers: {
    'Content-Type': 'multipart/form-data',  // 동적으로 Content-Type 설정
  },
})
```
