### PR TITLE
Feat : Dropdown 단일 선택으로 변경, Label에 htmlFor 프롭스 추가 

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -40,7 +40,7 @@ axiosInstance.interceptors.request.use(
       '/crew/regular',
       'crew/{crew_id}/regular',
       '/crew/{crew_id}/regular/{regular_id}',
-      // '/crew/{crew_id}',
+      '/crew/{crew_id}',
     ];
 
     // 토큰이 필요한 엔드포인트에만 토큰을 헤더에 추가

--- a/src/components/common/DateOnlyPicker.tsx
+++ b/src/components/common/DateOnlyPicker.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React, { useState } from 'react';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import { DateTime } from 'luxon';
+import Button from './Button';
+
+interface DatePickerProps {
+  onDateChange: (date: string | null) => void;
+  initialDate?: string | null;
+  error?: string;
+}
+
+const DateOnlyPicker = ({
+  onDateChange,
+  initialDate = null,
+  error,
+}: DatePickerProps) => {
+  const [selectedDate, setSelectedDate] = useState<string | null>(
+    initialDate || null,
+  );
+
+  const handleDateChange = (date: Date | null) => {
+    if (date) {
+      const newDate = DateTime.fromJSDate(date).toFormat('yyyy-MM-dd');
+      setSelectedDate(newDate);
+      onDateChange(newDate);
+    } else {
+      setSelectedDate(null);
+      onDateChange(null);
+    }
+  };
+
+  const clearSelectedDate = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault(); // 기본 동작 방지
+    setSelectedDate(null);
+    onDateChange(null);
+  };
+
+  return (
+    <div className="relative inline-block">
+      <DatePicker
+        selected={selectedDate ? new Date(selectedDate) : null}
+        onChange={handleDateChange}
+        dateFormat="yyyy-MM-dd"
+        className={`input input-bordered max-w-xs ${error && 'textarea-error'}`}
+        placeholderText="날짜를 선택하세요"
+      />
+
+      {selectedDate && (
+        <div className="mt-4 flex items-center gap-2">
+          <p>
+            선택된 날짜: <strong>{selectedDate}</strong>
+          </p>
+          <Button onClick={clearSelectedDate} size="sm">
+            선택 취소
+          </Button>
+        </div>
+      )}
+      {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
+    </div>
+  );
+};
+
+export default DateOnlyPicker;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -7,13 +7,12 @@ export interface DropdownOption {
 
 interface DropdownProps {
   options: DropdownOption[]; // 드롭다운에 표시할 옵션 배열
-  onChange: (value: string | string[] | number) => void;
+  onChange: (value: string | number) => void;
   placeholder?: string;
   required?: boolean;
-  multiple?: boolean; // 다중 선택 가능 여부
-  selectedValues?: string[]; // 선택된 값들
+  selectedValue?: string | number; // 선택된 값들
   width?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'; // 너비를 위한 프롭
-  disabled?: boolean;
+  disabled?: boolean; // 첫 번째 옵션(placeholder) disabled 여부
   error?: string;
 }
 
@@ -22,19 +21,13 @@ const Dropdown = ({
   onChange,
   placeholder = '',
   required = false,
-  multiple = false,
-  selectedValues = [],
+  selectedValue,
   width = 'xs',
   disabled = true,
   error,
 }: DropdownProps) => {
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = multiple
-      ? Array.from(e.target.selectedOptions, (option) => option.value)
-      : e.target.value;
-    if (onChange) {
-      onChange(value);
-    }
+    onChange(e.target.value);
   };
   const widthClass = `max-w-${width}`;
 
@@ -42,8 +35,7 @@ const Dropdown = ({
     <>
       <select
         className={`select select-bordered ${widthClass}  ${error && 'select-error'}`}
-        value={multiple ? undefined : selectedValues[0]}
-        multiple={multiple}
+        value={selectedValue || ''}
         onChange={handleChange}
         required={required}
       >
@@ -51,15 +43,7 @@ const Dropdown = ({
           {placeholder}
         </option>
         {options.map((option) => (
-          <option
-            key={option.id}
-            value={option.id}
-            selected={
-              multiple
-                ? selectedValues.includes(option.name)
-                : selectedValues[0] === option.name
-            }
-          >
+          <option key={option.id} value={option.id}>
             {option.name}
           </option>
         ))}

--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -7,6 +7,7 @@ interface LabelProps {
   required?: boolean;
   textSize?: 'xs' | 'sm' | 'base' | 'lg' | 'xl' | string;
   children: React.ReactNode;
+  htmlFor?: string;
 }
 
 const Label = ({
@@ -14,11 +15,12 @@ const Label = ({
   required = false,
   textSize = 'lg',
   children,
+  htmlFor,
 }: LabelProps) => {
   const textSizeClass = `text-${textSize}`;
 
   return (
-    <label className="form-control w-full py-2">
+    <label className="form-control w-full py-2" htmlFor={htmlFor}>
       <div className="label">
         <span className={`label-text ${textSizeClass}`}>
           {label}

--- a/src/components/common/TimePicker.tsx
+++ b/src/components/common/TimePicker.tsx
@@ -9,12 +9,14 @@ interface TimePickerProps {
   onTimeChange: (time: string | null) => void;
   initialTime?: string | null;
   error?: string;
+  placeholder?: string;
 }
 
 const TimePicker = ({
   onTimeChange,
   initialTime = null,
   error,
+  placeholder,
 }: TimePickerProps) => {
   const [selectedTime, setSelectedTime] = useState<string | null>(
     initialTime || null,
@@ -31,6 +33,9 @@ const TimePicker = ({
       setSelectedTime(newTime);
       setIsDatePickerOpen(false); // 시간 선택 후 드롭다운 닫기
       onTimeChange(newTime);
+    } else {
+      setSelectedTime(null);
+      onTimeChange(null);
     }
   };
 
@@ -54,9 +59,8 @@ const TimePicker = ({
           timeCaption="Time"
           dateFormat="HH:mm"
           className={`input input-bordered max-w-xs ${error && 'textarea-error'}`}
-          placeholderText="시간을 선택하세요"
+          placeholderText={placeholder}
           open={isDatePickerOpen} // 드롭다운 상태
-          onClickOutside={() => setIsDatePickerOpen(false)} // 드롭다운 외부 클릭 시 닫기
         />
       </div>
 


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
기존의 Dropdown 컴포넌트가 단일 선택과 다중 선택을 모두 지원하도록 설계되어 있었으나, 이로 인해 복잡성과 불필요한 코드가 포함되어 있었습니다. 또한, 실제 사용 사례에서는 단일 선택만 필요하므로 이를 단순화하고, 코드의 가독성과 유지보수성을 개선하고자 합니다.

추가적으로, Label 컴포넌트에서 접근성을 개선하기 위해 htmlFor 프롭스를 추가하였으며, Axios 인스턴스의 인터셉터에서 토큰이 필요 없는 publicEndpoints에 새로운 엔드포인트를 추가하였습니다.

### 이 PR에서 변경된 사항
**Dropdown 컴포넌트 수정**
- Dropdown 컴포넌트를 단일 선택 전용으로 변경.
- multiple 속성과 관련된 모든 로직 제거.
- selected 속성을 사용하는 대신, value 속성만을 사용하여 선택된 값을 관리.
- selectedValue를 string | number 타입으로 처리하여 단일 선택 시 선택된 값이 올바르게 반영되도록 개선.
- 배열 타입의 selectedValues는 삭제 (selectedValue로 수정한 것)

**Label 컴포넌트에 htmlFor 프롭스 추가**

**Axios 인스턴스 인터셉터의 publicEndpoints 배열에 새로운 엔드포인트를 추가하여, 해당 엔드포인트에서 토큰 없이 요청을 보낼 수 있도록 설정**

