### PR TITLE
Feature/common components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,8 @@ import Layout from '@/components/layout/Layout';
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 3000, // 3초 @서율님 제가 임의로 3초 처리 해놨습니다. 다른 의견 있으시면 수정해주세요!
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
     },
   },
 });

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -10,7 +10,7 @@ interface DropdownProps {
   onChange: (value: string | number) => void;
   placeholder?: string;
   required?: boolean;
-  selectedValue?: string | number; // 선택된 값들
+  selectedValue?: string | number | null; // 선택된 값들
   width?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'; // 너비를 위한 프롭
   disabled?: boolean; // 첫 번째 옵션(placeholder) disabled 여부
   error?: string;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -13,7 +13,7 @@ interface DropdownProps {
   selectedValue?: string | number | null; // 선택된 값들
   width?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'; // 너비를 위한 프롭
   disabled?: boolean; // 첫 번째 옵션(placeholder) disabled 여부
-  error?: string;
+  errorMessage?: string;
 }
 
 const Dropdown = ({
@@ -24,7 +24,7 @@ const Dropdown = ({
   selectedValue,
   width = 'xs',
   disabled = true,
-  error,
+  errorMessage,
 }: DropdownProps) => {
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     onChange(e.target.value);
@@ -34,7 +34,7 @@ const Dropdown = ({
   return (
     <>
       <select
-        className={`select select-bordered ${widthClass}  ${error && 'select-error'}`}
+        className={`select select-bordered ${widthClass}  ${errorMessage && 'select-error'}`}
         value={selectedValue || ''}
         onChange={handleChange}
         required={required}
@@ -48,7 +48,9 @@ const Dropdown = ({
           </option>
         ))}
       </select>
-      {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
+      {errorMessage && (
+        <p className="text-red-500 text-sm mt-1">{errorMessage}</p>
+      )}
     </>
   );
 };

--- a/src/components/common/ErrorComponent.tsx
+++ b/src/components/common/ErrorComponent.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface ErrorComponentProps {
+  message?: string;
+}
+
+const ErrorComponent = ({
+  message = '에러가 발생했습니다.',
+}: ErrorComponentProps) => {
+  return (
+    <div className="flex flex-col justify-center items-center h-full w-full text-center">
+      <div className="text-red-600 font-bold mb-2">{message}</div>
+    </div>
+  );
+};
+
+export default ErrorComponent;

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface LoadingSpinnerProps {
+  size?: 'xs' | 'xm' | 'md' | 'lg';
+  color?: string;
+}
+
+const LoadingSpinner = ({
+  size = 'md',
+  color = 'primary',
+}: LoadingSpinnerProps) => {
+  const sizeClassName = `loading-${size}`;
+  const colorClassName = `text-${color}`;
+  return (
+    <div className="flex justify-center items-center h-full w-full">
+      <span
+        className={`loading loading-spinner ${sizeClassName} ${colorClassName}`}
+      ></span>
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/src/components/common/RegionDropdown.tsx
+++ b/src/components/common/RegionDropdown.tsx
@@ -23,11 +23,15 @@ const RegionDropdown = ({
   disabled = true,
   errorMessage,
 }: RegionDropdownProps) => {
-  const { data: regions, isLoading, error } = useRegions();
+  const { data: regions, isLoading, isError, error } = useRegions();
 
   if (isLoading) return <LoadingSpinner />;
-  if (error)
-    return <ErrorComponent message="지역 정보를 불러오지 못했습니다." />;
+  if (isError)
+    return (
+      <ErrorComponent
+        message={error?.message || '지역 정보를 불러오지 못했습니다.'}
+      />
+    );
 
   // 드롭다운 값 변경 핸들러
   const handleRegionChange = (value: string | number) => {
@@ -36,7 +40,7 @@ const RegionDropdown = ({
 
   return (
     <Dropdown
-      options={regions}
+      options={regions || []}
       onChange={handleRegionChange}
       selectedValue={selectedRegion}
       placeholder={placeholder}

--- a/src/components/common/RegionDropdown.tsx
+++ b/src/components/common/RegionDropdown.tsx
@@ -5,15 +5,23 @@ import LoadingSpinner from './LoadingSpinner';
 import ErrorComponent from './ErrorComponent';
 
 interface RegionDropdownProps {
-  selectedRegion: string | number | null;
+  selectedRegion?: string | number | null;
   onRegionChange: (region: string | number) => void;
   placeholder?: string;
+  required?: boolean;
+  disabled?: boolean; // 첫 번째 옵션(placeholder) disabled 여부
+  errorMessage?: string;
+  width?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'; // 너비를 위한 프롭
 }
 
 const RegionDropdown = ({
   selectedRegion,
   onRegionChange,
   placeholder = '지역을 선택하세요.',
+  required = false,
+  width = 'xs',
+  disabled = true,
+  errorMessage,
 }: RegionDropdownProps) => {
   const { data: regions, isLoading, error } = useRegions();
 
@@ -32,6 +40,10 @@ const RegionDropdown = ({
       onChange={handleRegionChange}
       selectedValue={selectedRegion}
       placeholder={placeholder}
+      required={required}
+      disabled={disabled}
+      errorMessage={errorMessage}
+      width={width}
     />
   );
 };

--- a/src/components/common/RegionDropdown.tsx
+++ b/src/components/common/RegionDropdown.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useRegions } from '@/hooks/useRegions';
+import Dropdown from './Dropdown';
+import LoadingSpinner from './LoadingSpinner';
+import ErrorComponent from './ErrorComponent';
+
+interface RegionDropdownProps {
+  selectedRegion: string | number | null;
+  onRegionChange: (region: string | number) => void;
+  placeholder?: string;
+}
+
+const RegionDropdown = ({
+  selectedRegion,
+  onRegionChange,
+  placeholder = '지역을 선택하세요.',
+}: RegionDropdownProps) => {
+  const { data: regions, isLoading, error } = useRegions();
+
+  if (isLoading) return <LoadingSpinner />;
+  if (error)
+    return <ErrorComponent message="지역 정보를 불러오지 못했습니다." />;
+
+  // 드롭다운 값 변경 핸들러
+  const handleRegionChange = (value: string | number) => {
+    onRegionChange(value); // 상위 컴포넌트에 선택된 값 전달
+  };
+
+  return (
+    <Dropdown
+      options={regions}
+      onChange={handleRegionChange}
+      selectedValue={selectedRegion}
+      placeholder={placeholder}
+    />
+  );
+};
+
+export default RegionDropdown;

--- a/src/components/common/YearOfBirthDropdown.tsx
+++ b/src/components/common/YearOfBirthDropdown.tsx
@@ -37,7 +37,7 @@ const YearOfBirthDropdown = ({
     <Dropdown
       options={options}
       onChange={(value) => onYearChange(Number(value))}
-      selectedValue={selectedYear !== null ? String(selectedYear) : ''}
+      selectedValue={selectedYear ? String(selectedYear) : undefined}
       placeholder={placeholder}
       required={required}
       disabled={disabled}

--- a/src/components/common/YearOfBirthDropdown.tsx
+++ b/src/components/common/YearOfBirthDropdown.tsx
@@ -5,25 +5,31 @@ interface YearOfBirthDropdownProps {
   selectedYear: number | null;
   onYearChange: (year: number) => void;
   placeholder?: string;
-  error?: string; // 에러 메시지 프롭스
+  required?: boolean;
+  disabled?: boolean; // 첫 번째 옵션(placeholder) disabled 여부
+  errorMessage?: string;
+  width?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'; // 너비를 위한 프롭
 }
 
 const YearOfBirthDropdown = ({
   selectedYear,
   onYearChange,
   placeholder = '',
-  error,
+  required = false,
+  width = 'xs',
+  disabled = true,
+  errorMessage,
 }: YearOfBirthDropdownProps) => {
   const startYear = 1900;
   const endYear = new Date().getFullYear();
 
   const years = Array.from(
     { length: endYear - startYear + 1 },
-    (_, idx) => startYear + idx,
+    (_, idx) => endYear - idx,
   );
 
   const options = years.map((year) => ({
-    id: String(year),
+    id: year,
     name: String(year),
   }));
 
@@ -31,9 +37,12 @@ const YearOfBirthDropdown = ({
     <Dropdown
       options={options}
       onChange={(value) => onYearChange(Number(value))}
-      selectedValue={selectedYear ? String(selectedYear) : undefined}
+      selectedValue={selectedYear !== null ? String(selectedYear) : ''}
       placeholder={placeholder}
-      error={error}
+      required={required}
+      disabled={disabled}
+      errorMessage={errorMessage}
+      width={width}
     />
   );
 };

--- a/src/hooks/useRegions.ts
+++ b/src/hooks/useRegions.ts
@@ -1,13 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '@/apis/axiosInstance';
 
-const fetchRegions = async () => {
+interface Regions {
+  id: string;
+  name: string;
+}
+
+const fetchRegions = async (): Promise<Regions[]> => {
   const response = await axiosInstance.get('/region');
   return response.data;
 };
 
 export const useRegions = () => {
-  return useQuery({
+  return useQuery<Regions[], Error>({
     queryKey: ['region'],
     queryFn: fetchRegions,
     staleTime: Infinity,

--- a/src/hooks/useRegions.ts
+++ b/src/hooks/useRegions.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import axiosInstance from '@/apis/axiosInstance';
+
+const fetchRegions = async () => {
+  const response = await axiosInstance.get('/region');
+  return response.data;
+};
+
+export const useRegions = () => {
+  return useQuery({
+    queryKey: ['region'],
+    queryFn: fetchRegions,
+    staleTime: Infinity,
+  });
+};


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 공통 컴포넌트 및 기능의 추가와 기존 코드의 리팩토링을 통해 코드베이스의 일관성을 유지하고, 재사용성을 높이고자 함
- 기존 Dropdown, YearOfBirthDropdown 컴포넌트의 타입 오류와 프롭스 명명, 프롭스 누락 문제를 해결하여 코드의 가독성과 유지보수성을 향상시키기 위함
- 공통으로 사용되는 활동 지역 리스트를 호출하는 공통 커스텀 훅 구현하여 개발의 효율성 증진

### 이 PR에서 변경된 사항
1. **공통 컴포넌트 추가, 쿼리 기본값 수정**
   - `ErrorComponent`, `LoadingSpinner`, `RegionDropdown` 공통 컴포넌트들이 추가되었습니다.
   - 지역 선택 관련 API 호출을 위한 커스텀 훅이 추가되었습니다. (RegionDropdown이 이것들을 사용해 구현되었습니다. 드랍다운 외에 별도로 지역 호출을 하실 일이 있다면 이 훅을 사용하시면 될 것 같습니다.)
   - 리액트 쿼리의 디폴트 설정값을 임의로 수정되었습니다. (staleTime : 5분, gcTime : 10분)

2. **리팩토링**
   - `Dropdown` 컴포넌트의 `error` 프롭스 이름이` 'errorMessage'`로 변경되었습니다. (유효성 검사에 걸렷을 때의 메시지)
   - `RegionDropdown` 컴포넌트에 `Dropdown` 컴포넌트로 넘겨줄 추가적인 프롭스가 반영되었습니다.
   - `YearOfBirthDropdown`에 `Dropdown` 컴포넌트로 넘겨줄 추가적인 프롭스가 추가되었으며, 2024년 부터 시작되는 것으로 수정했습니다.
   - hooks디렉토리에 지역 목록 호출할 수 있는 useRegions가 추가되었습니다. 
   - 서버에서 내려오는 에러 메시지를 `RegionDropdown` 컴포넌트에 처리하는 로직이 추가되었습니다.

### 참고 스크린샷
- `RegionDropdown`에서 `useRegions`훅과 `LoadingSpinner`, `ErrorComponent `컴포넌트를 사용한 예시입니다. 이번 PR을 아우르는 예시 같아 첨부합니다. 
<img width="594" alt="image" src="https://github.com/user-attachments/assets/9664582d-37bf-44a0-aa27-7c0f641a5e94">
