### PR TITLE
refactor : 동일 엔드포인트 중에서 GET만 토큰이 필요없는 경우가 있어서 분리, 폼 관련 공통 컴포넌트 선택값 입력 안할 경우 Undefined로 넘어가도록 수정

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -27,9 +27,9 @@ axiosInstance.interceptors.request.use(
     const token = getAccessToken(); // 쿠키로 변경 가능
 
     // 토큰이 필요하지 않은 엔드포인트
-    // 로그인, 회원가입과 같은 비회원용 엔드포인트 목록입니다.
-    const pubicEndpoints = [
+    const publicEndpoints = [
       '/login',
+      'https://accounts.google.com/o/oauth2/v2/auth?client_id=570209002929-esgj2qidamovae074v43ivravvd4b3up.apps.googleusercontent.com&redirect_uri=http://localhost:8080/login/oauth&response_type=code&scope=email',
       '/user/signup',
       '/user/signup/email-send',
       '/user/signup/email-verify',
@@ -38,16 +38,31 @@ axiosInstance.interceptors.request.use(
       '/crew',
       '/region',
       '/crew/regular',
-      'crew/{crew_id}/regular',
+      '/crew/{crew_id}/regular',
       '/crew/{crew_id}/regular/{regular_id}',
       '/crew/{crew_id}',
     ];
 
+    // GET 메서드만 토큰이 필요 없는 엔드포인트
+    const publicGetEndpoints = [
+      '/crew',
+      '/crew/{crew_id}/regular',
+      '/crew/{crew_id}/regular/{regular_id}',
+      '/crew/{crew_id}',
+    ];
+
+    // 토큰이 필요 없는 엔드포인트인지 확인
+    const isPublicEndpoint = publicEndpoints.some((endpoint) =>
+      config.url?.startsWith(endpoint),
+    );
+
+    // GET 메서드로 토큰이 필요 없는 엔드포인트인지 확인
+    const isPublicGetEndpoint =
+      config.method === 'get' &&
+      publicGetEndpoints.some((endpoint) => config.url?.startsWith(endpoint));
+
     // 토큰이 필요한 엔드포인트에만 토큰을 헤더에 추가
-    if (
-      token &&
-      !pubicEndpoints.some((endpoint) => config.url?.startsWith(endpoint))
-    ) {
+    if (token && !isPublicEndpoint && !isPublicGetEndpoint) {
       if (config.headers) {
         config.headers.Authorization = `Bearer ${token}`;
       }

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -38,9 +38,6 @@ axiosInstance.interceptors.request.use(
       '/crew',
       '/region',
       '/crew/regular',
-      '/crew/{crew_id}/regular',
-      '/crew/{crew_id}/regular/{regular_id}',
-      '/crew/{crew_id}',
     ];
 
     // GET 메서드만 토큰이 필요 없는 엔드포인트

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -35,7 +35,6 @@ axiosInstance.interceptors.request.use(
       '/user/signup/email-verify',
       '/user/signup/nickname-verify',
       '/oauth2/authorization/google',
-      '/crew',
       '/region',
       '/crew/regular',
     ];

--- a/src/components/common/CheckBox.tsx
+++ b/src/components/common/CheckBox.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 interface CheckBoxProps {
-  options: { id: string | number; name: string }[]; // 옵션 배열 프롭스
-  selectedValues: string[];
-  onChange: (selectedValues: string[]) => void;
+  options: { id: string | number; name: string | number }[]; // 옵션 배열 프롭스
+  selectedValues?: (string | number)[];
+  onChange: (selectedValues?: (string | number)[]) => void;
   multiple?: boolean; // 다중 선택 가능 여부
   size?: 'xs' | 'sm' | 'md' | 'lg'; // 사이즈를 위한 프롭
   error?: string;
@@ -11,13 +11,13 @@ interface CheckBoxProps {
 
 const CheckBox = ({
   options,
-  selectedValues,
+  selectedValues = [],
   onChange,
   multiple = false,
   error,
 }: CheckBoxProps) => {
-  const handleCheckBoxChange = (id: string, checked: boolean) => {
-    let newSelectedValues: string[];
+  const handleCheckBoxChange = (id: string | number, checked: boolean) => {
+    let newSelectedValues: (string | number)[];
 
     if (multiple) {
       newSelectedValues = checked
@@ -27,7 +27,8 @@ const CheckBox = ({
       newSelectedValues = checked ? [id] : [];
     }
 
-    onChange(newSelectedValues);
+    // 선택된 값이 없다면 undefined를 반환
+    onChange(newSelectedValues.length > 0 ? newSelectedValues : undefined);
   };
 
   return (

--- a/src/components/common/DateOnlyPicker.tsx
+++ b/src/components/common/DateOnlyPicker.tsx
@@ -7,42 +7,42 @@ import { DateTime } from 'luxon';
 import Button from './Button';
 
 interface DatePickerProps {
-  onDateChange: (date: string | null) => void;
-  initialDate?: string | null;
+  onDateChange: (date?: string) => void;
+  initialDate?: string;
   error?: string;
 }
 
 const DateOnlyPicker = ({
   onDateChange,
-  initialDate = null,
+  initialDate,
   error,
 }: DatePickerProps) => {
-  const [selectedDate, setSelectedDate] = useState<string | null>(
-    initialDate || null,
+  const [selectedDate, setSelectedDate] = useState<string | undefined>(
+    initialDate,
   );
 
-  const handleDateChange = (date: Date | null) => {
+  const handleDateChange = (date?: Date) => {
     if (date) {
       const newDate = DateTime.fromJSDate(date).toFormat('yyyy-MM-dd');
       setSelectedDate(newDate);
       onDateChange(newDate);
     } else {
-      setSelectedDate(null);
-      onDateChange(null);
+      setSelectedDate(undefined);
+      onDateChange(undefined);
     }
   };
 
   const clearSelectedDate = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault(); // 기본 동작 방지
-    setSelectedDate(null);
-    onDateChange(null);
+    setSelectedDate(undefined);
+    onDateChange(undefined);
   };
 
   return (
     <div className="relative inline-block">
       <DatePicker
-        selected={selectedDate ? new Date(selectedDate) : null}
-        onChange={handleDateChange}
+        selected={selectedDate ? new Date(selectedDate) : undefined}
+        onChange={(date) => handleDateChange(date || undefined)}
         dateFormat="yyyy-MM-dd"
         className={`input input-bordered max-w-xs ${error && 'textarea-error'}`}
         placeholderText="날짜를 선택하세요"

--- a/src/components/common/DateOnlyPicker.tsx
+++ b/src/components/common/DateOnlyPicker.tsx
@@ -20,6 +20,11 @@ const DateOnlyPicker = ({
   const [selectedDate, setSelectedDate] = useState<string | undefined>(
     initialDate,
   );
+  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
+
+  const toggleDatePicker = () => {
+    setIsDatePickerOpen((prev) => !prev);
+  };
 
   const handleDateChange = (date?: Date) => {
     if (date) {
@@ -40,13 +45,16 @@ const DateOnlyPicker = ({
 
   return (
     <div className="relative inline-block">
-      <DatePicker
-        selected={selectedDate ? new Date(selectedDate) : undefined}
-        onChange={(date) => handleDateChange(date || undefined)}
-        dateFormat="yyyy-MM-dd"
-        className={`input input-bordered max-w-xs ${error && 'textarea-error'}`}
-        placeholderText="날짜를 선택하세요"
-      />
+      <div onClick={toggleDatePicker} className="cursor-pointer">
+        <DatePicker
+          selected={selectedDate ? new Date(selectedDate) : undefined}
+          onChange={(date) => handleDateChange(date || undefined)}
+          dateFormat="yyyy-MM-dd"
+          className={`input input-bordered max-w-xs ${error && 'textarea-error'}`}
+          placeholderText="날짜를 선택하세요"
+          open={isDatePickerOpen} // 드롭다운 상태
+        />
+      </div>
 
       {selectedDate && (
         <div className="mt-4 flex items-center gap-2">

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -7,10 +7,10 @@ export interface DropdownOption {
 
 interface DropdownProps {
   options: DropdownOption[]; // 드롭다운에 표시할 옵션 배열
-  onChange: (value: string | number) => void;
+  onChange: (value?: string | number) => void;
   placeholder?: string;
   required?: boolean;
-  selectedValue?: string | number | null; // 선택된 값들
+  selectedValue?: string | number; // 선택된 값들
   width?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'; // 너비를 위한 프롭
   disabled?: boolean; // 첫 번째 옵션(placeholder) disabled 여부
   errorMessage?: string;
@@ -35,7 +35,7 @@ const Dropdown = ({
     <>
       <select
         className={`select select-bordered ${widthClass}  ${errorMessage && 'select-error'}`}
-        value={selectedValue || ''}
+        value={selectedValue}
         onChange={handleChange}
         required={required}
       >

--- a/src/components/common/ImageUpload.tsx
+++ b/src/components/common/ImageUpload.tsx
@@ -4,18 +4,18 @@ import React, { useState } from 'react';
 import Avatar from './Avatar';
 
 interface ImageUploadProps {
-  onImageChange: (file: File | null) => void;
+  onImageChange: (file?: File) => void;
   error?: string; // 에러 메시지 프롭스
 }
 
 const ImageUpload = ({ onImageChange, error }: ImageUploadProps) => {
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files ? e.target.files[0] : null;
+    const file = e.target.files ? e.target.files[0] : undefined;
     if (file && file.type.startsWith('image/')) {
       onImageChange(file);
       // 시간 있을 때 프리뷰 구현
     } else {
-      onImageChange(null);
+      onImageChange(undefined);
     }
   };
 

--- a/src/components/common/NumberInput.tsx
+++ b/src/components/common/NumberInput.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 interface NumberInputProps {
-  value: number | null;
-  onChange: (value: number | null) => void;
+  value?: number;
+  onChange: (value?: number) => void;
   placeholder?: string;
   required?: boolean;
   min?: number; // 최소값 제한
@@ -28,17 +28,14 @@ const NumberInput = ({
 
     // 입력값 비어질 때 상태 업데이트
     if (inputValue === '') {
-      onChange(null);
+      onChange(undefined);
       return;
     }
 
     const numericValue = parseInt(inputValue, 10);
 
-    // 최소값
-    if (!isNaN(numericValue) && numericValue >= min) {
-      onChange(numericValue);
-    } else if (numericValue < min) {
-      onChange(min);
+    if (!isNaN(numericValue)) {
+      onChange(numericValue >= min ? numericValue : min); // 최소값보다 작으면 최소값으로 설정
     }
   };
 
@@ -47,7 +44,7 @@ const NumberInput = ({
       <input
         className={`input input-bordered w-full ${widthClass} ${error && 'input-error'}}`}
         type="text"
-        value={value !== null ? value : ''}
+        value={value}
         onChange={handleChange}
         placeholder={placeholder}
         required={required}

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
 
 interface PaginationProps {
-  totalItems: number;
-  itemsPerPage: number; // 한 페이지당 아이템
+  totalPages: number;
   currentPage: number;
   onPageChange: (page: number) => void;
   pageRangeDisplayed: number; // 표시할 페이지 범위
 }
 
 const Pagination = ({
-  totalItems,
-  itemsPerPage,
+  totalPages,
   currentPage,
   onPageChange,
   pageRangeDisplayed,
 }: PaginationProps) => {
-  const totalPages = Math.ceil(totalItems / itemsPerPage);
-
   // 페이지 구간 계산
   const currentRangeStart =
     Math.floor((currentPage - 1) / pageRangeDisplayed) * pageRangeDisplayed + 1;
@@ -27,40 +23,40 @@ const Pagination = ({
 
   const handlePreviousRange = () => {
     if (currentRangeStart > 1) {
-      onPageChange(currentRangeStart - pageRangeDisplayed);
+      onPageChange(currentRangeStart - pageRangeDisplayed - 1);
     }
   };
 
   const handleNextRange = () => {
     if (currentRangeEnd < totalPages) {
-      onPageChange(currentRangeEnd + 1);
+      onPageChange(currentRangeEnd);
     }
   };
 
   const handlePageClick = (page: number) => {
-    onPageChange(page);
+    onPageChange(page - 1);
   };
 
   const handleFirstPage = () => {
-    onPageChange(1);
+    onPageChange(0);
   };
 
   const handleLastPage = () => {
-    onPageChange(totalPages);
+    onPageChange(totalPages - 1);
   };
 
-  if (totalPages === 1) return null; // 페이지가 1개라면 표시x
+  if (totalPages <= 1) return null; // 페이지가 1개라면 표시x
 
   return (
     <div className="flex justify-center mx-auto space-x-2 mt-6">
       <button
         className={`join-item px-3 py-1 rounded-lg border border-transparent transition duration-200 ${
-          currentPage === 1
+          currentPage === 0
             ? 'text-gray-300 cursor-not-allowed'
             : 'text-primary hover:bg-gray-200 hover:text-white'
         }`}
         onClick={handleFirstPage}
-        disabled={currentPage === 1}
+        disabled={currentPage === 0}
       >
         《
       </button>
@@ -82,7 +78,7 @@ const Pagination = ({
           <button
             key={page}
             className={`join-item px-3 py-1 rounded-lg border border-transparent transition duration-200 ${
-              currentPage === page
+              currentPage === page - 1
                 ? 'bg-accent text-white'
                 : 'text-secondary hover:bg-gray-200 hover:text-white'
             }`}
@@ -106,12 +102,12 @@ const Pagination = ({
       </button>
       <button
         className={`join-item px-3 py-1 rounded-lg border border-transparent transition duration-200 ${
-          currentPage === totalPages
+          currentPage === totalPages - 1
             ? 'text-gray-300 cursor-not-allowed'
             : 'text-primary hover:bg-gray-200 hover:text-white'
         }`}
         onClick={handleLastPage}
-        disabled={currentPage === totalPages}
+        disabled={currentPage === totalPages - 1}
       >
         》
       </button>

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -15,26 +15,26 @@ const Pagination = ({
 }: PaginationProps) => {
   // 페이지 구간 계산
   const currentRangeStart =
-    Math.floor((currentPage - 1) / pageRangeDisplayed) * pageRangeDisplayed + 1;
+    Math.floor(currentPage / pageRangeDisplayed) * pageRangeDisplayed;
   const currentRangeEnd = Math.min(
     currentRangeStart + pageRangeDisplayed - 1,
-    totalPages,
+    totalPages - 1,
   );
 
   const handlePreviousRange = () => {
-    if (currentRangeStart > 1) {
-      onPageChange(currentRangeStart - pageRangeDisplayed - 1);
+    if (currentRangeStart > 0) {
+      onPageChange(currentRangeStart - 1);
     }
   };
 
   const handleNextRange = () => {
-    if (currentRangeEnd < totalPages) {
-      onPageChange(currentRangeEnd);
+    if (currentRangeEnd < totalPages - 1) {
+      onPageChange(currentRangeEnd + 1);
     }
   };
 
   const handlePageClick = (page: number) => {
-    onPageChange(page - 1);
+    onPageChange(page);
   };
 
   const handleFirstPage = () => {
@@ -62,12 +62,12 @@ const Pagination = ({
       </button>
       <button
         className={`join-item px-3 py-1 rounded-lg border border-transparent transition duration-200 ${
-          currentRangeStart === 1
+          currentRangeStart === 0
             ? 'text-gray-300 cursor-not-allowed'
             : 'text-primary hover:bg-gray-200 hover:text-white'
         }`}
         onClick={handlePreviousRange}
-        disabled={currentRangeStart === 1}
+        disabled={currentRangeStart === 0}
       >
         〈
       </button>
@@ -78,25 +78,25 @@ const Pagination = ({
           <button
             key={page}
             className={`join-item px-3 py-1 rounded-lg border border-transparent transition duration-200 ${
-              currentPage === page - 1
+              currentPage === page
                 ? 'bg-accent text-white'
                 : 'text-secondary hover:bg-gray-200 hover:text-white'
             }`}
             onClick={() => handlePageClick(page)}
           >
-            {page}
+            {page + 1}
           </button>
         );
       })}
 
       <button
         className={`join-item px-3 py-1 rounded-lg border border-transparent transition duration-200 ${
-          currentRangeEnd === totalPages
+          currentRangeEnd === totalPages - 1
             ? 'text-gray-300 cursor-not-allowed'
             : 'text-primary hover:bg-gray-200 hover:text-white'
         }`}
         onClick={handleNextRange}
-        disabled={currentRangeEnd === totalPages}
+        disabled={currentRangeEnd === totalPages - 1}
       >
         〉
       </button>

--- a/src/components/common/RegionDropdown.tsx
+++ b/src/components/common/RegionDropdown.tsx
@@ -5,8 +5,8 @@ import LoadingSpinner from './LoadingSpinner';
 import ErrorComponent from './ErrorComponent';
 
 interface RegionDropdownProps {
-  selectedRegion?: string | number | null;
-  onRegionChange: (region: string | number) => void;
+  selectedRegion?: string | number;
+  onRegionChange: (region?: string | number) => void;
   placeholder?: string;
   required?: boolean;
   disabled?: boolean; // 첫 번째 옵션(placeholder) disabled 여부
@@ -33,15 +33,10 @@ const RegionDropdown = ({
       />
     );
 
-  // 드롭다운 값 변경 핸들러
-  const handleRegionChange = (value: string | number) => {
-    onRegionChange(value); // 상위 컴포넌트에 선택된 값 전달
-  };
-
   return (
     <Dropdown
       options={regions || []}
-      onChange={handleRegionChange}
+      onChange={onRegionChange}
       selectedValue={selectedRegion}
       placeholder={placeholder}
       required={required}

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 interface TextInputProps {
-  value: string;
-  onChange: (value: string) => void;
+  value?: string;
+  onChange: (value?: string) => void;
   type?: string; // input 타입
   placeholder?: string;
   required?: boolean;
@@ -28,13 +28,19 @@ const TextInput = ({
   const inputWidthClass = width ? `max-w-${width}` : 'max-w-xs';
   const textareaWidthClass = width ? `w-${width}` : 'w-1/2';
 
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    onChange(e.target.value);
+  };
+
   return (
     <>
       {as === 'textarea' ? (
         <textarea
           className={`textarea textarea-bordered ${textareaWidthClass} ${error && 'textarea-error'}`}
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={handleChange}
           placeholder={placeholder}
           maxLength={maxLength}
           required={required}
@@ -45,7 +51,7 @@ const TextInput = ({
           className={`input input-bordered w-full ${inputWidthClass} ${error && 'input-error'}`}
           type={type}
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={handleChange}
           placeholder={placeholder}
           required={required}
           maxLength={maxLength}

--- a/src/components/common/TimePicker.tsx
+++ b/src/components/common/TimePicker.tsx
@@ -6,20 +6,20 @@ import { DateTime } from 'luxon';
 import Button from './Button';
 
 interface TimePickerProps {
-  onTimeChange: (time: string | null) => void;
-  initialTime?: string | null;
+  onTimeChange: (time?: string) => void;
+  initialTime?: string;
   error?: string;
   placeholder?: string;
 }
 
 const TimePicker = ({
   onTimeChange,
-  initialTime = null,
+  initialTime,
   error,
   placeholder,
 }: TimePickerProps) => {
-  const [selectedTime, setSelectedTime] = useState<string | null>(
-    initialTime || null,
+  const [selectedTime, setSelectedTime] = useState<string | undefined>(
+    initialTime,
   );
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
 
@@ -27,22 +27,22 @@ const TimePicker = ({
     setIsDatePickerOpen((prev) => !prev);
   };
 
-  const handleTimeChange = (time: Date | null) => {
+  const handleTimeChange = (time?: Date) => {
     if (time) {
       const newTime = DateTime.fromJSDate(time).toFormat('HH:mm');
       setSelectedTime(newTime);
       setIsDatePickerOpen(false); // 시간 선택 후 드롭다운 닫기
       onTimeChange(newTime);
     } else {
-      setSelectedTime(null);
-      onTimeChange(null);
+      setSelectedTime(undefined);
+      onTimeChange(undefined);
     }
   };
 
   const clearSelectedTime = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault(); // 기본 동작 방지
-    setSelectedTime(null);
-    onTimeChange(null);
+    setSelectedTime(undefined);
+    onTimeChange(undefined);
   };
 
   return (
@@ -50,9 +50,9 @@ const TimePicker = ({
       <div onClick={toggleDatePicker} className="cursor-pointer">
         <DatePicker
           selected={
-            selectedTime ? new Date(`1970-01-01T${selectedTime}:00`) : null
+            selectedTime ? new Date(`1970-01-01T${selectedTime}:00`) : undefined
           }
-          onChange={handleTimeChange}
+          onChange={(date) => handleTimeChange(date || undefined)}
           showTimeSelect
           showTimeSelectOnly
           timeIntervals={30}

--- a/src/components/common/TimePicker.tsx
+++ b/src/components/common/TimePicker.tsx
@@ -21,17 +21,17 @@ const TimePicker = ({
   const [selectedTime, setSelectedTime] = useState<string | undefined>(
     initialTime,
   );
-  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
+  const [isTimePickerOpen, setIsTimePickerOpen] = useState(false);
 
-  const toggleDatePicker = () => {
-    setIsDatePickerOpen((prev) => !prev);
+  const toggleTimePicker = () => {
+    setIsTimePickerOpen((prev) => !prev);
   };
 
   const handleTimeChange = (time?: Date) => {
     if (time) {
       const newTime = DateTime.fromJSDate(time).toFormat('HH:mm');
       setSelectedTime(newTime);
-      setIsDatePickerOpen(false); // 시간 선택 후 드롭다운 닫기
+      setIsTimePickerOpen(false); // 시간 선택 후 드롭다운 닫기
       onTimeChange(newTime);
     } else {
       setSelectedTime(undefined);
@@ -47,7 +47,7 @@ const TimePicker = ({
 
   return (
     <div className="relative inline-block">
-      <div onClick={toggleDatePicker} className="cursor-pointer">
+      <div onClick={toggleTimePicker} className="cursor-pointer">
         <DatePicker
           selected={
             selectedTime ? new Date(`1970-01-01T${selectedTime}:00`) : undefined
@@ -60,7 +60,7 @@ const TimePicker = ({
           dateFormat="HH:mm"
           className={`input input-bordered max-w-xs ${error && 'textarea-error'}`}
           placeholderText={placeholder}
-          open={isDatePickerOpen} // 드롭다운 상태
+          open={isTimePickerOpen} // 드롭다운 상태
         />
       </div>
 

--- a/src/components/common/YearOfBirthDropdown.tsx
+++ b/src/components/common/YearOfBirthDropdown.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Dropdown from './Dropdown';
 
 interface YearOfBirthDropdownProps {
-  selectedYear: number | null;
-  onYearChange: (year: number) => void;
+  selectedYear?: number;
+  onYearChange: (year?: number) => void;
   placeholder?: string;
   required?: boolean;
   disabled?: boolean; // 첫 번째 옵션(placeholder) disabled 여부
@@ -36,8 +36,8 @@ const YearOfBirthDropdown = ({
   return (
     <Dropdown
       options={options}
-      onChange={(value) => onYearChange(Number(value))}
-      selectedValue={selectedYear ? String(selectedYear) : undefined}
+      onChange={(value) => onYearChange(value ? Number(value) : undefined)}
+      selectedValue={selectedYear}
       placeholder={placeholder}
       required={required}
       disabled={disabled}


### PR DESCRIPTION
### 이 PR을 통해 해결하려는 문제
- 기존에는 토큰이 필요하지 않은 엔드포인트만을 구분했지만, 동일한 엔드포인트에서 GET 요청과 다른 요청 방식을 구분하지 못해 발생하는 문제를 해결하고자 합니다.
- 특히 `/crew`와 유사한 엔드포인트들에서 GET 요청 시에는 토큰이 필요 없지만, POST 요청 시에는 토큰이 필요한 경우를 처리하지 못하는 문제를 개선합니다.
- 선택 사항을 사용자가 입력하지 않았을 경우 처리 방식에 대해 논의한 내용을 반영했습니다.
- 서버에서 내려주는 응답 본문의 수정 사항을 반영해서 Pagination 수정

### 이 PR에서 변경된 사항
- 요청 인터셉터에서 여러 메서드 중 GET만 토큰이 필요없는 메서드 무관하게 토큰이 필요없는 엔드포인트로 세분화하여 구분했습니다.
- 예를들어, `/crew` 엔드포인트의 GET 요청은 토큰을 포함하지 않도록 하고, POST 요청은 토큰을 포함하도록 수정했습니다.
- 기타 토큰이 필요하지 않은 GET 요청에 대한 로직도 추가하여 공용 엔드포인트와의 구분을 더 명확히 했습니다.
- 폼 관련 공통 컴포넌트의 값을 입력하지 않았을 경우 undefined가 되도록 수정했습니다. (기존에는 null로 되어있었습니다.)
- 백엔드 서버에서 totalPages를 넘겨주는 것을 반영해서 Pagination 컴포넌트를 수정했습니다.

### 참고 스크린샷
<img width="364" alt="image" src="https://github.com/user-attachments/assets/fec3808c-78de-4f14-b167-ae1d2fd8af9c">


### 기타
- 작업하시다가 토큰이 필요없는 엔드포인트를 추가로 발견하시면 위 이미지 배열에 구분해서 넣어주시면 됩니다.