### PR TITLE
refactor : Hearder 아이콘 버튼 임시로 일반 버튼으로 수정 등

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -47,6 +47,7 @@ axiosInstance.interceptors.request.use(
       '/crew/{crew_id}/regular',
       '/crew/{crew_id}/regular/{regular_id}',
       '/crew/{crew_id}',
+      '/crew/{crew_id}/activity',
     ];
 
     // 토큰이 필요 없는 엔드포인트인지 확인

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -38,7 +38,7 @@ const Button = ({
 
   return (
     <button
-      className={`btn ${outlineClass} ${colorClass} ${sizeClass} ${textColorClass} ${wideClass}`}
+      className={`btn ${outlineClass} ${sizeClass} ${textColorClass} ${wideClass}  ${colorClass}`}
       disabled={disabled}
       onClick={onClick}
       type={type}

--- a/src/components/login/LoginMenu.tsx
+++ b/src/components/login/LoginMenu.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useRouter } from 'next/navigation';
 import AvatarWithDropdown from '../common/AvatarWithDropdown';
 import { useLoginUser } from '@/hooks/user/useLoginUser';
+import Button from '../common/Button';
 
 const LoginMenu = () => {
   const router = useRouter();
@@ -10,7 +11,25 @@ const LoginMenu = () => {
 
   return (
     <div className="flex items-center space-x-6">
-      <HeaderMenu
+      <div className="flex items-center space-x-3">
+        <Button
+          size="sm"
+          color="accent"
+          onClick={() => router.push('/joined-crews')}
+        >
+          마이 크루
+        </Button>
+        <Button
+          size="sm"
+          color="accent"
+          outline
+          onClick={() => router.push('/create-crew')}
+        >
+          크루 만들기
+        </Button>
+      </div>
+
+      {/* <HeaderMenu
         name={'마이 크루'}
         icon={faBell}
         onMenuClick={() => router.push('/joined-crews')}
@@ -19,7 +38,7 @@ const LoginMenu = () => {
         name={'크루 만들기'}
         icon={faBell}
         onMenuClick={() => router.push('/create-crew')}
-      />
+      /> */}
       {/* <HeaderMenu
         name={'메시지'}
         icon={faBell}


### PR DESCRIPTION
### 이 PR에서 변경된 사항
- 로그인 했을 때 `헤더 아이콘 버튼`의 아이콘을 수정해야하는데 시간부족으로 일단 일반 버튼으로 변경했습니다. **영상 촬영 전에 꼭 pull 부탁드립니다.**
- 인스턴스에 토큰이 필요없는 엔드포인트를 추가했습니다.

